### PR TITLE
Add printBlob and printUrl functions & EPL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
 
-/lib
+# /lib
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -65,8 +65,19 @@ Returns an object indicating if the printer is ready and if not returns the erro
 
 Prints a text string.
 
-You can use this method with simple text or add a string using the [ZPL language](https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf "ZPL language")
+You can use this method with simple text or add a string using the [ZPL language](https://www.zebra.com/content/dam/zebra/manuals/printers/common/programming/zpl-zbi2-pm-en.pdf "ZPL language").
 
+##### **printBlob(Blob)**
+
+Prints a Blob.
+
+This also allows printing using the [EPL language](https://www.zebra.com/us/en/support-downloads/knowledge-articles/ait/epl2-command-information-and-details.html).
+
+##### **printUrl(str)**
+
+Grab's the URL's content as Blob and send to the Printer.
+
+This also allows printing EPL.
 
 ## Example
 

--- a/lib/constants.d.ts
+++ b/lib/constants.d.ts
@@ -1,0 +1,1 @@
+export declare const API_URL = "http://localhost:9100/";

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.API_URL = void 0;
+exports.API_URL = 'http://localhost:9100/';

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,20 @@
+import { Device } from './types';
+export default class ZebraBrowserPrintWrapper {
+    device: Device;
+    getAvailablePrinters: () => Promise<any>;
+    getDefaultPrinter: () => Promise<Device>;
+    setPrinter: (device: Device) => void;
+    getPrinter: () => Device;
+    cleanUpString: (str: string) => string;
+    checkPrinterStatus: () => Promise<{
+        isReadyToPrint: boolean;
+        errors: string;
+    }>;
+    write: (data: string) => Promise<void>;
+    writeBlob: (data: Blob) => Promise<void>;
+    writeUrl: (url: string) => Promise<void>;
+    read: () => Promise<string>;
+    print: (text: string) => Promise<void>;
+    printBlob: (text: Blob) => Promise<void>;
+    printUrl: (url: string) => Promise<void>;
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,367 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var constants_1 = require("./constants");
+var ZebraBrowserPrintWrapper = /** @class */ (function () {
+    function ZebraBrowserPrintWrapper() {
+        var _this = this;
+        this.device = {};
+        this.getAvailablePrinters = function () { return __awaiter(_this, void 0, void 0, function () {
+            var config, endpoint, res, data, error_1;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        config = {
+                            method: 'GET',
+                            headers: {
+                                'Content-Type': 'text/plain;charset=UTF-8',
+                            },
+                        };
+                        endpoint = constants_1.API_URL + 'available';
+                        _a.label = 1;
+                    case 1:
+                        _a.trys.push([1, 4, , 5]);
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 2:
+                        res = _a.sent();
+                        return [4 /*yield*/, res.json()];
+                    case 3:
+                        data = _a.sent();
+                        if (data && data !== undefined && data.printer && data.printer !== undefined && data.printer.length > 0) {
+                            return [2 /*return*/, data.printer];
+                        }
+                        return [2 /*return*/, new Error('No printers available')];
+                    case 4:
+                        error_1 = _a.sent();
+                        throw new Error(error_1);
+                    case 5: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.getDefaultPrinter = function () { return __awaiter(_this, void 0, void 0, function () {
+            var config, endpoint, res, data, deviceRaw, name_1, deviceType, connection, uid, provider, manufacturer, error_2;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        config = {
+                            method: 'GET',
+                            headers: {
+                                'Content-Type': 'text/plain;charset=UTF-8',
+                            },
+                        };
+                        endpoint = constants_1.API_URL + 'default';
+                        _a.label = 1;
+                    case 1:
+                        _a.trys.push([1, 4, , 5]);
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 2:
+                        res = _a.sent();
+                        return [4 /*yield*/, res.text()];
+                    case 3:
+                        data = _a.sent();
+                        if (data && data !== undefined && typeof data !== 'object' && data.split('\n\t').length === 7) {
+                            deviceRaw = data.split('\n\t');
+                            name_1 = this.cleanUpString(deviceRaw[1]);
+                            deviceType = this.cleanUpString(deviceRaw[2]);
+                            connection = this.cleanUpString(deviceRaw[3]);
+                            uid = this.cleanUpString(deviceRaw[4]);
+                            provider = this.cleanUpString(deviceRaw[5]);
+                            manufacturer = this.cleanUpString(deviceRaw[6]);
+                            return [2 /*return*/, {
+                                    connection: connection,
+                                    deviceType: deviceType,
+                                    manufacturer: manufacturer,
+                                    name: name_1,
+                                    provider: provider,
+                                    uid: uid,
+                                    version: 0,
+                                }];
+                        }
+                        throw new Error("There's no default printer");
+                    case 4:
+                        error_2 = _a.sent();
+                        throw new Error(error_2);
+                    case 5: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.setPrinter = function (device) {
+            _this.device = device;
+        };
+        this.getPrinter = function () {
+            return _this.device;
+        };
+        this.cleanUpString = function (str) {
+            var arr = str.split(':');
+            var result = arr[1].trim();
+            return result;
+        };
+        this.checkPrinterStatus = function () { return __awaiter(_this, void 0, void 0, function () {
+            var result, errors, isReadyToPrint, isError, media, head, pause;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0: return [4 /*yield*/, this.write('~HQES')];
+                    case 1:
+                        _a.sent();
+                        return [4 /*yield*/, this.read()];
+                    case 2:
+                        result = _a.sent();
+                        errors = [];
+                        isReadyToPrint = false;
+                        isError = result.charAt(70);
+                        media = result.charAt(88);
+                        head = result.charAt(87);
+                        pause = result.charAt(84);
+                        isReadyToPrint = isError === '0';
+                        switch (media) {
+                            case '1':
+                                errors.push('Paper out');
+                                break;
+                            case '2':
+                                errors.push('Ribbon Out');
+                                break;
+                            case '4':
+                                errors.push('Media Door Open');
+                                break;
+                            case '8':
+                                errors.push('Cutter Fault');
+                                break;
+                            default:
+                                break;
+                        }
+                        switch (head) {
+                            case '1':
+                                errors.push('Printhead Overheating');
+                                break;
+                            case '2':
+                                errors.push('Motor Overheating');
+                                break;
+                            case '4':
+                                errors.push('Printhead Fault');
+                                break;
+                            case '8':
+                                errors.push('Incorrect Printhead');
+                                break;
+                            default:
+                                break;
+                        }
+                        if (pause === '1')
+                            errors.push('Printer Paused');
+                        if (!isReadyToPrint && errors.length === 0)
+                            errors.push('Error: Unknown Error');
+                        return [2 /*return*/, {
+                                isReadyToPrint: isReadyToPrint,
+                                errors: errors.join(),
+                            }];
+                }
+            });
+        }); };
+        this.write = function (data) { return __awaiter(_this, void 0, void 0, function () {
+            var endpoint, myData, config, error_3;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        endpoint = constants_1.API_URL + 'write';
+                        myData = {
+                            device: this.device,
+                            data: data,
+                        };
+                        config = {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'text/plain;charset=UTF-8',
+                            },
+                            body: JSON.stringify(myData),
+                        };
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 1:
+                        _a.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_3 = _a.sent();
+                        throw new Error(error_3);
+                    case 3: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.writeBlob = function (data) { return __awaiter(_this, void 0, void 0, function () {
+            var endpoint, deviceData, formData, config, error_4;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        endpoint = constants_1.API_URL + 'write';
+                        deviceData = {
+                            device: this.device
+                        };
+                        formData = new FormData;
+                        formData.append("json", JSON.stringify(deviceData));
+                        formData.append("blob", data);
+                        config = {
+                            method: "POST",
+                            body: formData,
+                        };
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 1:
+                        _a.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_4 = _a.sent();
+                        throw new Error(error_4);
+                    case 3: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.writeUrl = function (url) { return __awaiter(_this, void 0, void 0, function () {
+            var endpoint, deviceData, contentBlob, formData, config, error_5;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 3, , 4]);
+                        endpoint = constants_1.API_URL + 'write';
+                        deviceData = {
+                            device: this.device
+                        };
+                        return [4 /*yield*/, fetch(url).then(function (r) { return r.blob(); })];
+                    case 1:
+                        contentBlob = _a.sent();
+                        formData = new FormData;
+                        formData.append("json", JSON.stringify(deviceData));
+                        formData.append("blob", contentBlob);
+                        config = {
+                            method: 'POST',
+                            body: formData,
+                        };
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 2:
+                        _a.sent();
+                        return [3 /*break*/, 4];
+                    case 3:
+                        error_5 = _a.sent();
+                        throw new Error(error_5);
+                    case 4: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.read = function () { return __awaiter(_this, void 0, void 0, function () {
+            var endpoint, myData, config, res, data, error_6;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 3, , 4]);
+                        endpoint = constants_1.API_URL + 'read';
+                        myData = {
+                            device: this.device,
+                        };
+                        config = {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'text/plain;charset=UTF-8',
+                            },
+                            body: JSON.stringify(myData),
+                        };
+                        return [4 /*yield*/, fetch(endpoint, config)];
+                    case 1:
+                        res = _a.sent();
+                        return [4 /*yield*/, res.text()];
+                    case 2:
+                        data = _a.sent();
+                        return [2 /*return*/, data];
+                    case 3:
+                        error_6 = _a.sent();
+                        throw new Error(error_6);
+                    case 4: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.print = function (text) { return __awaiter(_this, void 0, void 0, function () {
+            var error_7;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, this.write(text)];
+                    case 1:
+                        _a.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_7 = _a.sent();
+                        throw new Error(error_7);
+                    case 3: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.printBlob = function (text) { return __awaiter(_this, void 0, void 0, function () {
+            var error_8;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, this.writeBlob(text)];
+                    case 1:
+                        _a.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_8 = _a.sent();
+                        throw new Error(error_8);
+                    case 3: return [2 /*return*/];
+                }
+            });
+        }); };
+        this.printUrl = function (url) { return __awaiter(_this, void 0, void 0, function () {
+            var error_9;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 2, , 3]);
+                        return [4 /*yield*/, this.writeUrl(url)];
+                    case 1:
+                        _a.sent();
+                        return [3 /*break*/, 3];
+                    case 2:
+                        error_9 = _a.sent();
+                        throw new Error(error_9);
+                    case 3: return [2 /*return*/];
+                }
+            });
+        }); };
+    }
+    return ZebraBrowserPrintWrapper;
+}());
+exports.default = ZebraBrowserPrintWrapper;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,0 +1,9 @@
+export interface Device {
+    name: string;
+    deviceType: string;
+    connection: string;
+    uid: string;
+    provider: string;
+    manufacturer: string;
+    version: number;
+}

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zebra-browser-print-wrapper",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Zebra Browser Print Javascript Wrapper",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -16,6 +16,7 @@
         "url": "git+https://github.com/naxels/zebra-browser-print-wrapper.git"
     },
     "keywords": [
+        "epl",
         "zpl",
         "zebra",
         "zebra programming language",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zebra-browser-print-wrapper",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "Zebra Browser Print Javascript Wrapper",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",
@@ -13,7 +13,7 @@
     "dependencies": {},
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/lhilario/zebra-browser-print-wrapper.git"
+        "url": "git+https://github.com/naxels/zebra-browser-print-wrapper.git"
     },
     "keywords": [
         "zpl",

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,31 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
+  writeUrl = async (url: string) => {
+    try {
+      const endpoint = API_URL + 'write';
+
+      const deviceData = {
+        device: this.device
+      };
+
+      const contentBlob = await fetch(url).then(r => r.blob());
+
+      var formData = new FormData;
+      formData.append("json", JSON.stringify(deviceData));
+      formData.append("blob", contentBlob);
+
+      const config = {
+        method: 'POST',
+        body: formData,
+      };
+
+      await fetch(endpoint, config);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
   read = async () => {
     try {
       const endpoint = API_URL + 'read';
@@ -224,6 +249,14 @@ export default class ZebraBrowserPrintWrapper {
   printBlob = async (text: Blob) => {
     try {
       await this.writeBlob(text);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  printUrl = async (url: string) => {
+    try {
+      await this.writeUrl(url);
     } catch (error) {
       throw new Error(error);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
-  writeForm = async (data: string) => {
+  writeForm = async (data: BlobPart[]) => {
     try {
       const endpoint = API_URL + 'write';
 
@@ -176,7 +176,7 @@ export default class ZebraBrowserPrintWrapper {
 
       var formData = new FormData;
       formData.append("json", JSON.stringify(myData));
-      formData.append("blob", data);  
+      formData.append("blob", new Blob(data, {type: 'application/epl'}));  
 
       const config = {
         method: 'POST',
@@ -224,7 +224,7 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
-  printForm = async (text: string) => {
+  printForm = async (text: BlobPart[]) => {
     try {
       await this.writeForm(text);
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,32 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
+  writeForm = async (data: string) => {
+    try {
+      const endpoint = API_URL + 'write';
+
+      const myData = {
+        device: this.device
+      };
+
+      var formData = new FormData;
+      formData.append("json", JSON.stringify(myData));
+      formData.append("blob", data);  
+
+      const config = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'text/plain;charset=UTF-8',
+        },
+        body: formData,
+      };
+
+      await fetch(endpoint, config);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
   read = async () => {
     try {
       const endpoint = API_URL + 'read';
@@ -193,6 +219,14 @@ export default class ZebraBrowserPrintWrapper {
   print = async (text: string) => {
     try {
       await this.write(text);
+    } catch (error) {
+      throw new Error(error);
+    }
+  };
+
+  printForm = async (text: string) => {
+    try {
+      await this.writeForm(text);
     } catch (error) {
       throw new Error(error);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ export default class ZebraBrowserPrintWrapper {
       const config = {
         method: 'POST',
         headers: {
-          'Content-Type': 'text/plain;charset=UTF-8',
+          'Content-Type': 'text/html',
         },
         body: formData,
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,23 +166,20 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
-  writeForm = async (data: BlobPart[]) => {
+  writeBlob = async (data: Blob) => {
     try {
       const endpoint = API_URL + 'write';
 
-      const myData = {
+      const deviceData = {
         device: this.device
       };
 
       var formData = new FormData;
-      formData.append("json", JSON.stringify(myData));
-      formData.append("blob", new Blob(data, {type: 'application/epl'}));  
+      formData.append("json", JSON.stringify(deviceData));
+      formData.append("blob", data);
 
       const config = {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'text/html',
-        },
+        method: "POST",
         body: formData,
       };
 
@@ -224,9 +221,9 @@ export default class ZebraBrowserPrintWrapper {
     }
   };
 
-  printForm = async (text: BlobPart[]) => {
+  printBlob = async (text: Blob) => {
     try {
-      await this.writeForm(text);
+      await this.writeBlob(text);
     } catch (error) {
       throw new Error(error);
     }


### PR DESCRIPTION
Originally we used Base64 to decode the EPL/ZPL labels and then send to the Zebra printer
however this would result in strange behaviour especially on images in EPL.

Adding these 2 functions, allows printing of EPL as well
and prevents decoding errors that could cause character issues when printing a string.

Peeked at the Zebra Browser Javascript library to see how they accomplished this in their samples
and discovered they used the FormData API.

ps: for the 2 new functions, had to disable Content-Type header else it would result in CORS errors.

I know very little about Typescript and Javascript, so feel free to
merge the functions and allow an easier developer-user function for printing the different ways.